### PR TITLE
Taccess 00002

### DIFF
--- a/group_vars/hq-tinkeraccess-server.yml
+++ b/group_vars/hq-tinkeraccess-server.yml
@@ -1,5 +1,4 @@
 ---
 tinkeraccess_server_enabled: True
 tinkeraccess_client_enabled: False
-tinkeraccess_client: tinkerclient
 

--- a/host_vars/lasercutterpi
+++ b/host_vars/lasercutterpi
@@ -4,4 +4,5 @@ tinkeraccess_log_level: 10
 tinkeraccess_reboot_on_error: True
 tinkeraccess_auto_update_interval: 30
 tinkeraccess_server_address: http://taccess:5000
+tinkerpi_wifi_disabled: False
 

--- a/host_vars/lasercutterpi
+++ b/host_vars/lasercutterpi
@@ -1,0 +1,4 @@
+---
+tinkeraccess_device_id: 3
+tinkeraccess_server_address: http://taccess:5000
+

--- a/host_vars/tablesawpi
+++ b/host_vars/tablesawpi
@@ -4,4 +4,5 @@ tinkeraccess_log_level: 10
 tinkeraccess_reboot_on_error: True
 tinkeraccess_auto_update_interval: 30
 tinkeraccess_server_address: http://taccess:5000
+tinkerpi_wifi_disabled: False
 

--- a/host_vars/tablesawpi
+++ b/host_vars/tablesawpi
@@ -1,0 +1,4 @@
+---
+tinkeraccess_device_id: 2
+tinkeraccess_server_address: http://taccess:5000
+

--- a/host_vars/tablesawpi
+++ b/host_vars/tablesawpi
@@ -1,4 +1,7 @@
 ---
 tinkeraccess_device_id: 2
+tinkeraccess_log_level: 10
+tinkeraccess_reboot_on_error: True
+tinkeraccess_auto_update_interval: 30
 tinkeraccess_server_address: http://taccess:5000
 

--- a/host_vars/testpi
+++ b/host_vars/testpi
@@ -1,7 +1,7 @@
 ---
-tinkeraccess_device_id: 3
+tinkeraccess_device_id: 1
 tinkeraccess_log_level: 10
 tinkeraccess_reboot_on_error: True
 tinkeraccess_auto_update_interval: 30
-tinkeraccess_server_address: http://taccess:5000
+tinkeraccess_server_address: http://taccess-test:5000
 

--- a/production.ini
+++ b/production.ini
@@ -22,6 +22,10 @@ marvin ansible_host=10.2.0.29
 [hq-tinkeraccess-server]
 taccess ansible_host=10.2.1.2
 
+[hq-tinkeraccess-client]
+lasercutterpi ansible_host=10.2.1.3
+tablesawpi ansible_host=10.2.1.5
+
 [hq:children]
 hq-omd
 hq-vmhost
@@ -29,6 +33,7 @@ hq-nas
 hq-shell
 hq-unifi
 hq-tinkeraccess-server
+hq-tinkeraccess-client
 hq-graylog
 
 ##################################################

--- a/roles/tinkeraccess/README.md
+++ b/roles/tinkeraccess/README.md
@@ -19,7 +19,7 @@ git, service, shell, template
 | tinkeraccess_server | Name of tinkerAccess server service | tinkerserver |
 | tinkeraccess_log_level | Integer level of logging | 40 |
 | tinkeraccess_reboot_on_error | If True, reboot the supported RPi when any unhandled error is encountered | False |
-| tinkeraccess_reboot_delay | Integer number of seconds to wait before rebooting | 5 |
+| tinkeraccess_reboot_delay | Integer number of seconds to wait before rebooting | 300 |
 | tinkeraccess_auto_update | If True, update tinkerAccess automatically | False |
 | tinkeraccess_auto_update_interval | Integer number of minutes to wait betwen auto update checks | 5 |
 | tinkeraccess_device_id | Unique integer identifier for a client, as configure in the tinker-access-client | 0 |

--- a/roles/tinkeraccess/README.md
+++ b/roles/tinkeraccess/README.md
@@ -1,6 +1,6 @@
 # tinkeraccess
 
-A role to configure a Raspberry Pi so it can act as a server for the TinkerAccess system.
+A role to configure a Raspberry Pi as a server or client for the TinkerAccess system.
 
 ## Requirements
 
@@ -13,10 +13,18 @@ git, service, shell, template
 | -------- | ----------- | ------------- |
 | tinkeraccess_repo_dest | Location on the RPi to place the git repo | /root/tinkerAccess |
 | tinkeraccess_repo_source | URL to pull git repo from | https://github.com/TinkerMill/tinkerAccess.git |
-| tinkeraccess_server_enabled | Switch to enable/disable tinkerAccess client | False |
-| tinkeraccess_client_enabled | Switch to enable/disable tinkerAccess server | True | 
-| tinkeraccess_client | Name of tinkerAccess client | tinker-access-client |
-| tinkeraccess_server | Name of tinkerAccess server | tinkerserver |
+| tinkeraccess_server_enabled | If True, enable tinkerAccess server | False |
+| tinkeraccess_client_enabled | If True, enable tinkerAccess client | True | 
+| tinkeraccess_client | Name of tinkerAccess client service | tinker-access-client |
+| tinkeraccess_server | Name of tinkerAccess server service | tinkerserver |
+| tinkeraccess_log_level | Integer level of logging | 40 |
+| tinkeraccess_reboot_on_error | If True, reboot the supported RPi when any unhandled error is encountered | False |
+| tinkeraccess_reboot_delay | Integer number of seconds to wait before rebooting | 5 |
+| tinkeraccess_auto_update | If True, update tinkerAccess automatically | False |
+| tinkeraccess_auto_update_interval | Integer number of minutes to wait betwen auto update checks | 5 |
+| tinkeraccess_device_id | Unique integer identifier for a client, as configure in the tinker-access-client | 0 |
+| tinkeraccess_logout_coast_time | Integer number of seconds to wait for the physical machine to stop after power has been disabled. (i.e. a blade to stop spinning etc...) | 0 |
+| tinkeraccess_server_address | The tinker-access-server's api address | http://localhost:5000 |
 
 ## Dependencies
 

--- a/roles/tinkeraccess/defaults/main.yml
+++ b/roles/tinkeraccess/defaults/main.yml
@@ -6,4 +6,12 @@ tinkeraccess_server_enabled: False
 tinkeraccess_client_enabled: True
 tinkeraccess_client: tinker-access-client
 tinkeraccess_server: tinkerserver
+tinkeraccess_log_level: 10
+tinkeraccess_reboot_on_error: true
+tinkeraccess_reboot_delay: 5
+tinkeraccess_auto_update: false
+tinkeraccess_auto_update_interval: 30
+tinkeraccess_device_id: 999
+tinkeraccess_logout_coast_time: 7
+tinkeraccess_server_address: http://taccess-test:5000
 

--- a/roles/tinkeraccess/defaults/main.yml
+++ b/roles/tinkeraccess/defaults/main.yml
@@ -6,12 +6,12 @@ tinkeraccess_server_enabled: False
 tinkeraccess_client_enabled: True
 tinkeraccess_client: tinker-access-client
 tinkeraccess_server: tinkerserver
-tinkeraccess_log_level: 10
-tinkeraccess_reboot_on_error: true
+tinkeraccess_log_level: 40
+tinkeraccess_reboot_on_error: False
 tinkeraccess_reboot_delay: 5
-tinkeraccess_auto_update: false
-tinkeraccess_auto_update_interval: 30
-tinkeraccess_device_id: 999
-tinkeraccess_logout_coast_time: 7
-tinkeraccess_server_address: http://taccess-test:5000
+tinkeraccess_auto_update: False
+tinkeraccess_auto_update_interval: 5
+tinkeraccess_device_id: 0
+tinkeraccess_logout_coast_time: 0
+tinkeraccess_server_address: http://localhost:5000
 

--- a/roles/tinkeraccess/defaults/main.yml
+++ b/roles/tinkeraccess/defaults/main.yml
@@ -8,7 +8,7 @@ tinkeraccess_client: tinker-access-client
 tinkeraccess_server: tinkerserver
 tinkeraccess_log_level: 40
 tinkeraccess_reboot_on_error: False
-tinkeraccess_reboot_delay: 5
+tinkeraccess_reboot_delay: 300
 tinkeraccess_auto_update: False
 tinkeraccess_auto_update_interval: 5
 tinkeraccess_device_id: 0

--- a/roles/tinkeraccess/tasks/main.yml
+++ b/roles/tinkeraccess/tasks/main.yml
@@ -8,6 +8,7 @@
     clone: yes
     dest: "{{ tinkeraccess_repo_dest }}"
     repo: "{{ tinkeraccess_repo_source }}"
+  ignore_errors: yes
   tags:
     - tinkeraccess
     - files

--- a/roles/tinkeraccess/templates/tinker-access-client.conf.j2
+++ b/roles/tinkeraccess/templates/tinker-access-client.conf.j2
@@ -1,5 +1,14 @@
 # {{ ansible_managed }}
 [config]
-server_address: taccess-test:5000
-device_id: testpi
+log_level:{{ tinkeraccess_log_level }}
+
+reboot_on_error:{{ tinkeraccess_reboot_on_error }}
+reboot_delay:{{ tinkeraccess_reboot_delay }}
+
+auto_update:{{ tinkeraccess_auto_update }}
+auto_update_interval:{{ tinkeraccess_auto_update_interval }}
+
+device_id:{{ tinkeraccess_device_id }}
+logout_coast_time:{{ tinkeraccess_logout_coast_time }}
+server_address:{{ tinkeraccess_server_address }}
 

--- a/roles/tinkerpi/defaults/main.yml
+++ b/roles/tinkerpi/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for tinkerpi
+tinkerpi_wifi_disabled: true
+

--- a/roles/tinkerpi/tasks/main.yml
+++ b/roles/tinkerpi/tasks/main.yml
@@ -26,6 +26,7 @@
     mode: 0644
     owner: root
     state: present
+  when: tinkerpi_wifi_disabled
   with_items:
     - brcmfmac
     - brcmutil


### PR DESCRIPTION
Looked over this with Bruce.  

When run, these changes will bring the TinkerAccess clients into the Ansible fold.

To check:
ansible-playbook site.yml -u pi -i production.ini -l hq-tinkeraccess-client -C

To run:
ansible-playbook site.yml -u pi -i production.ini -l hq-tinkeraccess-client

Thanks!